### PR TITLE
Nav Bar

### DIFF
--- a/src/components/LeftNavBar.css
+++ b/src/components/LeftNavBar.css
@@ -1,0 +1,7 @@
+.contentNav{
+    display:block;
+    height:calc(50vh);
+    overflow: auto;
+    overscroll-behavior-y: auto;
+    scrollbar-gutter: stable;
+}

--- a/src/components/LeftNavBar.css
+++ b/src/components/LeftNavBar.css
@@ -1,7 +1,0 @@
-.contentNav{
-    display:block;
-    height:calc(50vh);
-    overflow: auto;
-    overscroll-behavior-y: auto;
-    scrollbar-gutter: stable;
-}

--- a/src/components/LeftNavBar.js
+++ b/src/components/LeftNavBar.js
@@ -1,34 +1,38 @@
 import { BsFillPersonFill, TbTextDirectionRtl, TbLayoutDashboard,
   IoNotificationsSharp, MdBackupTable, GiBulletBill, SiVirtualbox, RxDashboard, ImEnter, AiOutlineForm,
 } from '../utils/icons';
+import "./LeftNavBar.css"
 
 export default function LeftNavBar() {
- let navItemCSS = 'flex items-center py-3 hover:bg-neutral-900 rounded-lg active:bg-pink-600'
-
+ let navItemCSS = 'flex items-center py-3 hover:bg-neutral-900 rounded-lg active:bg-pink-600 mx-4'
+ let iconCSS = "p-1 text-3xl"
+ 
   return (
-    <div className="w-screen grid grid-cols-2 border-[2px] border-white ">
-      <div className="w-[180px] h-[calc(100%-4px)] fixed top-[2px] left-5 border-[2px] border-black bg-gradient-to-b from-neutral-800 to-neutral-950 rounded-lg">
-        <div className="mx-4 text-white text-sm">
-          <div className='flex items-center py-3 border-b-2 mb-2'><TbLayoutDashboard className="p-1" />Material Dashboard </div>
-          <div className="block h-[calc(50vh)] overflow-auto overscroll-y-auto">
+    <div className="w-screen grid grid-cols-2 border-[2px] border-white">
+      <div className="w-[250px] h-[calc(100%-40px)] fixed top-[2px] left-5 border-[2px] border-black bg-gradient-to-b from-neutral-800 to-neutral-950 rounded-lg align-tems">
+        <div className=' text-white border-yellow-400 border-b py-10 flex justify-center items-center mb-2'>
+           <div className='flex items-center mb-2 mx-4 absolute border-4 border-green-400 z-40'><TbLayoutDashboard className={iconCSS} />Material Dashboard 2</div>
+        </div>
+        <div className=" text-white text-sm">
+          <div class="contentNav">
             <ul>
-              <li className={navItemCSS}> <RxDashboard className="p-1"/> Dashboard</li>
-              <li className={navItemCSS}> <MdBackupTable className="p-1"/> Tables</li>
-              <li className={navItemCSS}> <GiBulletBill className="p-1"/>Billing </li>
-              <li className={navItemCSS}> <SiVirtualbox className="p-1"/>Virtual Reality</li>
-              <li className={navItemCSS}> <TbTextDirectionRtl className="p-1"/>RTL</li>
-              <li className={navItemCSS}> <IoNotificationsSharp className="p-1"/> Notifications</li>
+              <li className={navItemCSS}> <RxDashboard className={iconCSS}/> Dashboard</li>
+              <li className={navItemCSS}> <MdBackupTable className={iconCSS}/> Tables</li>
+              <li className={navItemCSS}> <GiBulletBill className={iconCSS}/>Billing </li>
+              <li className={navItemCSS}> <SiVirtualbox className={iconCSS}/>Virtual Reality</li>
+              <li className={navItemCSS}> <TbTextDirectionRtl className={iconCSS}/>RTL</li>
+              <li className={navItemCSS}> <IoNotificationsSharp className={iconCSS}/> Notifications</li>
             </ul>
-            <h5 className="py-3">Account Pages</h5>
+            <h5 className="py-3 mx-4">Account Pages</h5>
             <ul>
-              <li className={navItemCSS}> <BsFillPersonFill className="p-1"/>Profile</li>
-              <li className={navItemCSS}> <ImEnter className="p-1"/>Sign In</li>
-              <li className={navItemCSS}> <AiOutlineForm className="p-1"/>Sign Up</li>
+              <li className={navItemCSS}> <BsFillPersonFill className={iconCSS}/>Profile</li>
+              <li className={navItemCSS}> <ImEnter className={iconCSS}/>Sign In</li>
+              <li className={navItemCSS}> <AiOutlineForm className={iconCSS}/>Sign Up</li>
             </ul>
           </div>
-        </div>
-        <div className='block absolute bottom-[2px]'>
-          <button className="m-4 text-white bg-pink-600 rounded-lg text-center py-2 px-6 text-sm">Update To Pro</button>
+          <div className='absolute bottom-[-2px] left-[-2.5px] pt-[10px] rounded-lg bg-neutral-950 z-30'>
+            <button className="mx-4 mb-4 w-[calc(250px-32px)] text-white bg-pink-600 rounded-lg text-center py-2 px-6 text-xs font-bold">UPGRADE TO PRO</button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/LeftNavBar.js
+++ b/src/components/LeftNavBar.js
@@ -1,7 +1,6 @@
 import { BsFillPersonFill, TbTextDirectionRtl, TbLayoutDashboard,
   IoNotificationsSharp, MdBackupTable, GiBulletBill, SiVirtualbox, RxDashboard, ImEnter, AiOutlineForm,
 } from '../utils/icons';
-import "./LeftNavBar.css"
 
 export default function LeftNavBar() {
  let navItemCSS = 'flex items-center py-3 hover:bg-neutral-900 rounded-lg active:bg-pink-600 mx-4'
@@ -14,7 +13,7 @@ export default function LeftNavBar() {
            <div className='flex items-center mb-2 mx-4 absolute z-40'><TbLayoutDashboard className={iconCSS} />Material Dashboard 2</div>
         </div>
         <div className=" text-white text-sm">
-          <div class="contentNav">
+          <div className="h-[calc(50vh)] overflow-auto overflowBehaviorY scrollbarGutter block">
             <ul>
               <li className={navItemCSS}> <RxDashboard className={iconCSS}/> Dashboard</li>
               <li className={navItemCSS}> <MdBackupTable className={iconCSS}/> Tables</li>

--- a/src/components/LeftNavBar.js
+++ b/src/components/LeftNavBar.js
@@ -13,7 +13,7 @@ export default function LeftNavBar() {
            <div className='flex items-center mb-2 mx-4 absolute z-40'><TbLayoutDashboard className={iconCSS} />Material Dashboard 2</div>
         </div>
         <div className=" text-white text-sm">
-          <div className="h-[calc(50vh)] overflow-auto overflowBehaviorY scrollbarGutter block">
+          <div className="h-[calc(50vh)] block overflow-auto overflowBehaviorY scrollbarGutter">
             <ul>
               <li className={navItemCSS}> <RxDashboard className={iconCSS}/> Dashboard</li>
               <li className={navItemCSS}> <MdBackupTable className={iconCSS}/> Tables</li>

--- a/src/components/LeftNavBar.js
+++ b/src/components/LeftNavBar.js
@@ -11,7 +11,7 @@ export default function LeftNavBar() {
     <div className="w-screen grid grid-cols-2 border-[2px] border-white">
       <div className="w-[250px] h-[calc(100%-40px)] fixed top-[2px] left-5 border-[2px] border-black bg-gradient-to-b from-neutral-800 to-neutral-950 rounded-lg align-tems">
         <div className=' text-white border-yellow-400 border-b py-10 flex justify-center items-center mb-2'>
-           <div className='flex items-center mb-2 mx-4 absolute border-4 border-green-400 z-40'><TbLayoutDashboard className={iconCSS} />Material Dashboard 2</div>
+           <div className='flex items-center mb-2 mx-4 absolute z-40'><TbLayoutDashboard className={iconCSS} />Material Dashboard 2</div>
         </div>
         <div className=" text-white text-sm">
           <div class="contentNav">

--- a/src/components/MainContent.js
+++ b/src/components/MainContent.js
@@ -27,10 +27,10 @@ export default function MainContent() {
         </div>
         {/* Company info section */}
         <div className="col-start-1 col-span-6 row-start-2 row-end-4 grid grid-cols-4 border-[2px] border-black">
-          <CompanyInfo icon={<FaCouch style={{backgroundColor: 'white'}} />} iconbg="bg-slate-700" text={`Today's Money`} number="$53k" stat="+55%" stattext="than last week" />
+          <CompanyInfo icon={<FaCouch className='text-white'/>} iconbg="bg-slate-700" text={`Today's Money`} number="$53k" stat="+55%" stattext="than last week" />
           <CompanyInfo icon={<BsPersonFill />} iconbg="bg-pink-400" text={`Today's Users`} number="2,300" stat="+3%" stattext="than last month" />
           <CompanyInfo icon={<BsPersonFill />} iconbg="bg-green-400" text="New Clients" number="3,462" stat="-2%" stattext="than yesterday" />
-          <CompanyInfo icon={<FaCouch />} iconbg="bg-blue-400" text="Sales" number="$103,430" stat="+5%" stattext="than yesterday" />
+          <CompanyInfo icon={<FaCouch className='text-white' />} iconbg="bg-blue-400" text="Sales" number="$103,430" stat="+5%" stattext="than yesterday" />
         </div>
         {/* graphs section */}
         <div className="col-start-1 col-span-4 row-start-4 row-end-7 border-[2px] border-black">Graphs</div>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+
+
+@layer utilities {
+  .scrollbar::-webkit-scrollbar-thumb:hover {
+    background-color: rgb(107 114 128);
+  }
+  .scrollbar::-webkit-scrollbar-track:hover {
+    background-color: rgb(209 213 219);
+  }
+}
 body {
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,9 +18,16 @@ module.exports = {
         '11': '11',
         '12': '12',
         '13': '13',
-      }
+      },
+      scrollbarGutter: {
+        'stable':'stable',
+      },
+      overflowBehaviorY:{
+        'auto':'auto',
+      },
     },
   },
+  variants: {},
   plugins: [],
 }
 


### PR DESCRIPTION
Created Nav Bar component that contains 5 options of the dashboard and 3 parts Account Pages. Component is positioned on the left side of the page (Width of the Company Main Page has been accounted for). 

![Screen Shot 2023-04-18 at 12 15 48 PM](https://user-images.githubusercontent.com/100870645/232841314-f56730a1-be7c-4229-b049-7441255423a9.png)

Nav bar will create overflow automatically when viewport shrinks to no longer fit all options on the page. 

> Scroll bar is normally dark unless hovered over
![Screen Shot 2023-04-18 at 12 16 14 PM](https://user-images.githubusercontent.com/100870645/232842101-e1a41415-b7cf-4f32-9f1c-687d8ec7f5f9.png)

> Options will light up to a subtle dark black when hovered over 
![Screen Shot 2023-04-18 at 12 20 30 PM](https://user-images.githubusercontent.com/100870645/232842053-193e2481-1aa6-4f88-bfc6-bdddb0baf427.png)

"Upgrade to Pro" button stays in position when the viewport shrinks
> Button does not currently take user anywhere
> Button will stop when reaching the Dashboard header (options will slowly disappear as the viewport shrinks) 
> > Note: this works on Chrome // Does not appear to have the same behaviour in Firefox 
![Screen Shot 2023-04-18 at 12 18 24 PM](https://user-images.githubusercontent.com/100870645/232842841-2953696d-5430-4e30-b14f-bef6c33e1876.png)
![Screen Shot 2023-04-18 at 12 28 08 PM](https://user-images.githubusercontent.com/100870645/232842993-7310a0b0-2c44-4eb3-8eb6-84f1b7a260cc.png)


