### PR TITLE
feat: create GraphCard component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16181,16 +16181,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
-      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=12.20"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {
@@ -28770,9 +28770,9 @@
       }
     },
     "typescript": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.3.tgz",
-      "integrity": "sha512-xv8mOEDnigb/tN9PSMTwSEqAnUvkoXMQlicOb0IUVDBSQCgBSaAAROUZYy2IcUy5qU6XajK5jjjO7TMWqBTKZA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true
     },
     "unbox-primitive": {

--- a/src/components/GraphCard.js
+++ b/src/components/GraphCard.js
@@ -1,0 +1,20 @@
+import { BsClock } from "../utils/icons"
+
+export default function GraphCard({source, alternate, boldText, detailText, updateText}) {
+  return(
+    <div className='card w-[48.5%] shadow-md rounded-xl bg-white p-6 min-w-[300px] h-[327px] relative'>
+            <div className='w-[calc(100%-48px)] h-3/5 absolute -top-4 z-index-2'>
+              <img className='rounded-xl shadow-md object-fill h-full w-full' src={source} alt={alternate}/>
+            </div>
+            <div className='w-[calc(100%-48px)] absolute bottom-12 z-index-2'>
+              <h6 className='font-semibold text-base text-[#344767]'>{boldText}</h6>
+              <p className='text-sm mb-4 text-[#7b809a]'>{detailText}</p>
+              <hr className='dark horizontal h-px opacity-25 m-4 color-inherit'/>
+            </div>
+            <div className='flex w-[calc(100%-48px)] absolute bottom-6 z-index-2'>
+              <BsClock className="w-[14px] h-[21px] mr-1 fill-[#7b809a]"/>
+              <p className='text-sm text-[#7b809a]'>{updateText}</p>
+            </div>
+          </div>
+  )
+}

--- a/src/components/MainContent.js
+++ b/src/components/MainContent.js
@@ -1,11 +1,12 @@
 import { 
-  BsFillPersonFill, FiMenu, FcSettings, IoNotificationsSharp, FaCouch, BsPersonFill
+  BsFillPersonFill, FiMenu, FcSettings, IoNotificationsSharp, FaCouch, BsPersonFill, BsClock
 } from '../utils/icons';
 import CompanyInfo from './CompanyInfo';
+import GraphCard from './GraphCard';
 
 export default function MainContent() {
   return (
-    <div className="w-screen h-screen grid grid-cols-2 border-[2px] border-white overflow-y-auto">
+    <div className="w-screen h-screen grid grid-cols-2 border-[2px] border-white overflow-y-auto bg-[#f0f2f5]">
       <div className="w-[calc(100vw-238px)] h-full ml-[218px] grid grid-cols-6 grid-rows-12 border-[2px] border-black">
         {/* Nav section */}
         <div className="col-start-1 col-end-7 row-start-1 row-end-2 flex justify-between border-[2px] border-blue-300 text-sm">
@@ -26,14 +27,34 @@ export default function MainContent() {
           </div>
         </div>
         {/* Company info section */}
-        <div className="col-start-1 col-span-6 row-start-2 row-end-4 grid grid-cols-4 border-[2px] border-black">
+        <div className="col-start-1 col-span-6 row-start-2 row-end-4 grid grid-cols-4">
           <CompanyInfo icon={<FaCouch style={{backgroundColor: 'white'}} />} iconbg="bg-slate-700" text={`Today's Money`} number="$53k" stat="+55%" stattext="than last week" />
           <CompanyInfo icon={<BsPersonFill />} iconbg="bg-pink-400" text={`Today's Users`} number="2,300" stat="+3%" stattext="than last month" />
           <CompanyInfo icon={<BsPersonFill />} iconbg="bg-green-400" text="New Clients" number="3,462" stat="-2%" stattext="than yesterday" />
           <CompanyInfo icon={<FaCouch />} iconbg="bg-blue-400" text="Sales" number="$103,430" stat="+5%" stattext="than yesterday" />
         </div>
         {/* graphs section */}
-        <div className="col-start-1 col-span-4 row-start-4 row-end-7 border-[2px] border-black">Graphs</div>
+        <div className="col-start-1 col-span-4 row-start-4 row-end-7 flex gap-4 mt-4 px-[12px] justify-between">
+          <GraphCard
+            source={'http://placekitten.com/400/400'}
+            alternate={'kitten place holder'}
+            boldText={'Website Views'}
+            detailText={'Last Campaign Performace'}
+            updateText={'capaign sent 2 days ago'}
+          />
+          <GraphCard
+            source={'http://placekitten.com/400/400'}
+            alternate={'kitten place holder'}
+            boldText={'Daily Sales'}
+            detailText={
+              <div>
+                <span className='font-semibold'>(+15%)</span>
+                <span> increase in today sales.</span>
+              </div>}
+            updateText={'updated 4 min ago'}
+          />
+          
+        </div>
         {/* Project section */}
         <div className="col-start-1 col-span-4 row-start-7 row-end-12 inline-block border-[2px] border-black">Project info</div>
         {/* grpah and orders section */}


### PR DESCRIPTION
## Summary
* Create a reusable GraphCard component that takes in multiple parameters to render on the card.
* The graph component is directly below the `CompanyInfo.js` section.
* Responsiveness has not been added yet, but the size of the component is fixed, as per the provided demo page.

## Notes
* The styling uses Tailwind (no css files)
* The graphs have been replaced with kitten images as placeholders, until a suitable graph is able to function in its place.

## Screenshots
![image](https://user-images.githubusercontent.com/104564844/233835014-879a057b-6d0c-4805-a9e1-ad63dce0da68.png)
